### PR TITLE
CORS header enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Enable the security plugin
 * ``script.disable_dynamic: true`` Dynamic scripts are unsafe and can potentially tamper this plugin (not needed for ES 1.2 and above)
 * ``http.port: 9200`` Define exactly one port, Port ranges are not permitted
 
+Enable CORS if needed
+* ``security.cors.enabled: true`` Enable or disable cross-origin resource sharing, i.e. whether a browser on another origin can do requests to Elasticsearch. Defaults to false.
+* ``security.cors.allow-origin: $hostname`` Which origins to allow. Defaults to \*, i.e. any origin.
+* ``security.cors.max-age: 1728000`` Browsers send a "preflight" OPTIONS-request to determine CORS settings. Defines how long the result should be cached for. Defaults to 1728000 (20 days).
+* ``security.cors.allow-methods: "OPTIONS, HEAD, GET, POST, PUT, DELETE"`` Which methods to allow. Defaults to "OPTIONS, HEAD, GET, POST, PUT, DELETE"
+* ``security.cors.allow-headers: "X-Requested-With, Content-Type, Content-Length, X-HTTP-Method-Override, Origin, Accept, Authorization"`` Which headers to allow. Defaults to "X-Requested-With, Content-Type, Content-Length, X-HTTP-Method-Override, Origin, Accept, Authorization".
+* ``security.cors.allow-credentials: true`` Whether the Access-Control-Allow-Credentials header should be returned. Note: This header is only returned, when the setting is set to true. Defaults to false.
+
 Setup Kerberos
 * ``security.kerberos.mode: waffle|spnegoad|none`` Kerberos implementation (spnegoad is tomcat-built in Kerberos/SPNEGO support)
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>com.github.salyh.elasticsearch</groupId>
 	<artifactId>elasticsearch-security-plugin</artifactId>
-	<version>0.0.2.Beta9-ea1.4</version>
+	<version>0.0.2.Beta9-ea2</version>
 	<packaging>jar</packaging>
 
 	<name>elasticsearch-security-plugin</name>

--- a/src/main/java/org/elasticsearch/plugins/security/filter/ActionPathFilter.java
+++ b/src/main/java/org/elasticsearch/plugins/security/filter/ActionPathFilter.java
@@ -58,39 +58,43 @@ public class ActionPathFilter extends SecureRestFilter {
 					new TomcatUserRoleCallback(request
 							.getHttpServletRequest(),securityService.getSettings().get("security.ssl.userattribute")));
 
-			if (permLevel == PermLevel.NONE) {
-				SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
+      if ( securityService.getSettings().getAsBoolean("security.cors.enabled", false) && !request.method().toString().equals("OPTIONS")) {
+        log.debug("Request Method is " + request.method() + ", checking security");
+
+			  if (permLevel == PermLevel.NONE) {
+				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
 						"No permission (at all)");
-				return;
-			}
+				  return;
+			  }
 
-			if (permLevel.ordinal() < PermLevel.ALL.ordinal()
+			  if (permLevel.ordinal() < PermLevel.ALL.ordinal()
 					&& SecurityUtil.isAdminRequest(request)) {
-				SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
+				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
 						"No permission (for admin actions)");
-				return;
-			}
+				  return;
+			  }
 
-			if (permLevel.ordinal() < PermLevel.READWRITE.ordinal()
+			  if (permLevel.ordinal() < PermLevel.READWRITE.ordinal()
 					&& SecurityUtil.isWriteRequest(request,securityService.isStrictModeEnabled())) {
-				SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
+				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
 						"No permission (for write actions)");
-				return;
-			}
+				  return;
+			  }
 
-			if (permLevel == PermLevel.READONLY
+			  if (permLevel == PermLevel.READONLY
 					&& !SecurityUtil.isReadRequest(request,securityService.isStrictModeEnabled())) {
-				SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
+				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
 						"No permission (for read actions)");
-				return;
-			}
+				  return;
+			  }
 			
-			// Ram Kotamarja - START
-			// adding code to modify request modification before it hits elastic
-			// search to apply the search filters
-			modifiyKibanaRequest(request, channel);
-			// Ram Kotamaraja - END
-			
+			  // Ram Kotamarja - START
+			  // adding code to modify request modification before it hits elastic
+			  // search to apply the search filters
+			  modifiyKibanaRequest(request, channel);
+			  // Ram Kotamaraja - END
+
+      }
 
 			filterChain.continueProcessing(request, channel);
 			return;

--- a/src/main/java/org/elasticsearch/plugins/security/filter/ActionPathFilter.java
+++ b/src/main/java/org/elasticsearch/plugins/security/filter/ActionPathFilter.java
@@ -82,26 +82,30 @@ public class ActionPathFilter extends SecureRestFilter {
       }
 
       if (evalthem) {
+
+        if ( !securityService.getSettings().getAsBoolean("security.module.kibana.special", false) ) {
         log.debug("Evaluate the returned permissions");
 
-        if (permLevel == PermLevel.NONE) {
-          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (at all)");
-          return;
-        }
+          if (permLevel == PermLevel.NONE) {
+            SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (at all)");
+            return;
+          }
 
-        if (permLevel.ordinal() < PermLevel.ALL.ordinal() && SecurityUtil.isAdminRequest(request)) {
-          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for admin actions)");
-          return;
-        }
+          if (permLevel.ordinal() < PermLevel.ALL.ordinal() && SecurityUtil.isAdminRequest(request)) {
+            SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for admin actions)");
+            return;
+          }
 
-        if (permLevel.ordinal() < PermLevel.READWRITE.ordinal() && SecurityUtil.isWriteRequest(request,securityService.isStrictModeEnabled())) {
-          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for write actions)");
-          return;
-        }
+          if (permLevel.ordinal() < PermLevel.READWRITE.ordinal() && SecurityUtil.isWriteRequest(request,securityService.isStrictModeEnabled())) {
+            SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for write actions)");
+            return;
+          }
 
-        if (permLevel == PermLevel.READONLY && !SecurityUtil.isReadRequest(request,securityService.isStrictModeEnabled())) {
-          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for read actions)");
-          return;
+          if (permLevel == PermLevel.READONLY && !SecurityUtil.isReadRequest(request,securityService.isStrictModeEnabled())) {
+            SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for read actions)");
+            return;
+          }
+
         }
 
         modifiyKibanaRequest(request, channel);

--- a/src/main/java/org/elasticsearch/plugins/security/filter/ActionPathFilter.java
+++ b/src/main/java/org/elasticsearch/plugins/security/filter/ActionPathFilter.java
@@ -18,261 +18,239 @@ import org.elasticsearch.rest.RestStatus;
 
 public class ActionPathFilter extends SecureRestFilter {
 
-	public ActionPathFilter(final SecurityService securityService) {
-		super(securityService);
+  public ActionPathFilter(final SecurityService securityService) {
+    super(securityService);
 
-	}
+  }
 
-	@Override
-	public void processSecure(final TomcatHttpServerRestRequest request,
-			final TomcatHttpServerRestChannel channel,
-			final RestFilterChain filterChain) {
+  @Override
+  public void processSecure(final TomcatHttpServerRestRequest request,
+      final TomcatHttpServerRestChannel channel,
+      final RestFilterChain filterChain) {
 
-		if (SecurityUtil.stringContainsItemFromListAsTypeOrIndex(
-				request.path(), SecurityUtil.BUILT_IN_ADMIN_COMMANDS)) {
-			log.warn("Index- or Typename should not contains admin commands like "
-					+ Arrays.toString(SecurityUtil.BUILT_IN_ADMIN_COMMANDS));
-		}
+    if (SecurityUtil.stringContainsItemFromListAsTypeOrIndex( request.path(), SecurityUtil.BUILT_IN_ADMIN_COMMANDS)) {
+      log.warn("Index- or Typename should not contains admin commands like " + Arrays.toString(SecurityUtil.BUILT_IN_ADMIN_COMMANDS));
+    }
 
-		if (SecurityUtil.stringContainsItemFromListAsTypeOrIndex(
-				request.path(), securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_READ_COMMANDS_STRICT : SecurityUtil.BUILT_IN_READ_COMMANDS_LAX)) {
-			log.warn("Index- or Typename should not contains search commands like "
-					+ Arrays.toString(securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_READ_COMMANDS_STRICT : SecurityUtil.BUILT_IN_READ_COMMANDS_LAX));
-		}
+    if (SecurityUtil.stringContainsItemFromListAsTypeOrIndex( request.path(), securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_READ_COMMANDS_STRICT : SecurityUtil.BUILT_IN_READ_COMMANDS_LAX)) {
+      log.warn("Index- or Typename should not contains search commands like "
+          + Arrays.toString(securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_READ_COMMANDS_STRICT : SecurityUtil.BUILT_IN_READ_COMMANDS_LAX));
+    }
 
-		if (SecurityUtil.stringContainsItemFromListAsTypeOrIndex(
-				request.path(), securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_WRITE_COMMANDS_STRICT : SecurityUtil.BUILT_IN_WRITE_COMMANDS_LAX)) {
-			log.warn("Index- or Typename should not contains write commands like "
-					+ Arrays.toString(securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_WRITE_COMMANDS_STRICT : SecurityUtil.BUILT_IN_WRITE_COMMANDS_LAX));
-		}
+    if (SecurityUtil.stringContainsItemFromListAsTypeOrIndex( request.path(), securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_WRITE_COMMANDS_STRICT : SecurityUtil.BUILT_IN_WRITE_COMMANDS_LAX)) {
+      log.warn("Index- or Typename should not contains write commands like "
+          + Arrays.toString(securityService.isStrictModeEnabled()?SecurityUtil.BUILT_IN_WRITE_COMMANDS_STRICT : SecurityUtil.BUILT_IN_WRITE_COMMANDS_LAX));
+    }
 
-		try {
+    try {
 
-			final PermLevel permLevel = new PermLevelEvaluator(
-					securityService.getXContentSecurityConfiguration(
-							getType(), getId()))
-			.evaluatePerm(
-					SecurityUtil.getIndices(request),
-					SecurityUtil.getTypes(request),
-					getClientHostAddress(request),
-					new TomcatUserRoleCallback(request
-							.getHttpServletRequest(),securityService.getSettings().get("security.ssl.userattribute")));
+      final PermLevel permLevel = new PermLevelEvaluator(
+          securityService.getXContentSecurityConfiguration(getType(), getId())).evaluatePerm(
+            SecurityUtil.getIndices(request),
+            SecurityUtil.getTypes(request),
+            getClientHostAddress(request),
+            new TomcatUserRoleCallback(request.getHttpServletRequest(),securityService.getSettings().get("security.ssl.userattribute")));
+      
+      String secondpath = null;
 
-      if ( securityService.getSettings().getAsBoolean("security.cors.enabled", false) && !request.method().toString().equals("OPTIONS")) {
-        log.debug("Request Method is " + request.method() + ", checking security");
-
-			  if (permLevel == PermLevel.NONE) {
-				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
-						"No permission (at all)");
-				  return;
-			  }
-
-			  if (permLevel.ordinal() < PermLevel.ALL.ordinal()
-					&& SecurityUtil.isAdminRequest(request)) {
-				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
-						"No permission (for admin actions)");
-				  return;
-			  }
-
-			  if (permLevel.ordinal() < PermLevel.READWRITE.ordinal()
-					&& SecurityUtil.isWriteRequest(request,securityService.isStrictModeEnabled())) {
-				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
-						"No permission (for write actions)");
-				  return;
-			  }
-
-			  if (permLevel == PermLevel.READONLY
-					&& !SecurityUtil.isReadRequest(request,securityService.isStrictModeEnabled())) {
-				  SecurityUtil.send(request, channel, RestStatus.FORBIDDEN,
-						"No permission (for read actions)");
-				  return;
-			  }
-			
-			  // Ram Kotamarja - START
-			  // adding code to modify request modification before it hits elastic
-			  // search to apply the search filters
-			  modifiyKibanaRequest(request, channel);
-			  // Ram Kotamaraja - END
-
+      try {
+        secondpath = request.path().split("/")[2];
+        log.debug("Second path is: "+secondpath);
+      }
+      catch (Exception e) {
+        log.debug("Request path split failed: " + e.getMessage());
       }
 
-			filterChain.continueProcessing(request, channel);
-			return;
-		} catch (final MalformedConfigurationException e) {
-			log.error("Cannot parse security configuration ", e);
-			SecurityUtil.send(request, channel,
-					RestStatus.INTERNAL_SERVER_ERROR,
-					"Cannot parse security configuration");
+      boolean evalthem;
+      evalthem = true;
 
-			return;
-		} catch (final Exception e) {
-			log.error("Generic error: ", e);
-			SecurityUtil.send(request, channel,
-					RestStatus.INTERNAL_SERVER_ERROR,
-					"Generic error, see log for details");
+      if (securityService.getSettings().getAsBoolean("security.cors.enabled", false) && request.method().toString().equals("OPTIONS")) { 
+        evalthem = false;
+      } else if (securityService.getSettings().getAsBoolean("security.module.kibana.special", false) && request.path().equals("/_nodes")) { 
+        evalthem = false;
+      } else if (securityService.getSettings().getAsBoolean("security.module.kibana.special", false) && secondpath.equals("_aliases")) { 
+        evalthem = false;
+      } else if (securityService.getSettings().getAsBoolean("security.module.kibana.special", false) && secondpath.equals("_mapping")) { 
+        evalthem = false;
+      }
 
-			return;
-		}
+      if (secondpath != null) {
+        if ( securityService.getSettings().getAsBoolean("security.module.kibana.special", false) && 
+            permLevel.ordinal() >= PermLevel.READONLY.ordinal() && secondpath.equals("_search") && SecurityUtil.isReadRequest(request,securityService.isStrictModeEnabled()) ) {
+          evalthem = false;
+        }
+      }
 
-	}
-	
-	/**
-	 * Method added to modify the request on the fly to
-	 * allow it to process generic queries coming from kibana by
-	 * validating against the security framework (contributed by Ram Kotamaraja)
-	 * @param request
-	 */
-	private void modifiyKibanaRequest(
-			final TomcatHttpServerRestRequest request,
-			final TomcatHttpServerRestChannel channel) {
+      if (evalthem) {
+        log.debug("Evaluate the returned permissions");
 
-		List<String> reqTypesList = SecurityUtil.getTypes(request);
-		if (reqTypesList != null && !reqTypesList.isEmpty()
-				&& reqTypesList.size() > 0) {
-			// This means, there is a type specified in the request and so there
-			// is not need to do anything as the framework will take care of the
-			// type level security
-			log.debug("Not modifying the request (for kibana) as there is one or more types already associated with the request");
-			reqTypesList = null;
-			return;
-		}
+        if (permLevel == PermLevel.NONE) {
+          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (at all)");
+          return;
+        }
 
-		String kibanaPermLevel = null;
-		try {
-			kibanaPermLevel = securityService.getXContentSecurityConfiguration(
-					getType(), getKibanaId());
-		} catch (Exception e) {
-			log.debug("No Kibana configuration found, so continuing the rest of the process: "+e.getMessage());
-			return;
-		}
+        if (permLevel.ordinal() < PermLevel.ALL.ordinal() && SecurityUtil.isAdminRequest(request)) {
+          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for admin actions)");
+          return;
+        }
 
-		List<String> kibanaTypesList = null;
-		List<String> authorizedTypesList = new ArrayList<String>();
-		try {
-			if (kibanaPermLevel != null && kibanaPermLevel.length() > 0) {
-				kibanaTypesList = securityService.getKibanaTypes(SecurityUtil
-						.getIndices(request));
-			}
+        if (permLevel.ordinal() < PermLevel.READWRITE.ordinal() && SecurityUtil.isWriteRequest(request,securityService.isStrictModeEnabled())) {
+          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for write actions)");
+          return;
+        }
 
-			final String reqContent = request.content().toUtf8();
-			String modifiedContent = reqContent;
+        if (permLevel == PermLevel.READONLY && !SecurityUtil.isReadRequest(request,securityService.isStrictModeEnabled())) {
+          SecurityUtil.send(request, channel, RestStatus.FORBIDDEN, "No permission (for read actions)");
+          return;
+        }
 
-			// checking where the original request has any types
-			List<String> requestTypes = SecurityUtil.getTypes(request);
+        modifiyKibanaRequest(request, channel);
+      
+      }
 
-			// If original request has any requests, then skip the logic below
-			// as
-			// permission evaluation has to be done based on that specific type
-			if (requestTypes == null || requestTypes.isEmpty()
-					|| requestTypes.size() == 0) {
-				if (kibanaTypesList != null) {
+      filterChain.continueProcessing(request, channel);
+      return;
 
-					// determine authorized types list
-					
+    } catch (final MalformedConfigurationException e) {
+      log.error("Cannot parse security configuration ", e);
+      SecurityUtil.send(request, channel, RestStatus.INTERNAL_SERVER_ERROR, "Cannot parse security configuration");
 
-					Iterator<String> kibanaTypesItr = kibanaTypesList
-							.iterator();
+      return;
 
-					while (kibanaTypesItr.hasNext()) {
+    } catch (final Exception e) {
+      log.error("Generic error: ", e);
+      SecurityUtil.send(request, channel, RestStatus.INTERNAL_SERVER_ERROR, "Generic error, see log for details");
 
-						List<String> kibanaType = new ArrayList<String>();
-						kibanaType.add((String) kibanaTypesItr.next());
-						final PermLevel permLevel = new PermLevelEvaluator(
-								securityService
-										.getXContentSecurityConfiguration(
-												getType(), getId()))
-								.evaluatePerm(
-										SecurityUtil.getIndices(request),
-										// SecurityUtil.getTypes(request),
-										kibanaType,
-										getClientHostAddress(request),
-										new TomcatUserRoleCallback(
-												request.getHttpServletRequest(),
-												securityService
-														.getSettings()
-														.get("security.ssl.userattribute")));
+      return;
+    }
 
-						log.debug("Kibana perm level = "+permLevel);
+  }
+  
+  /**
+   * Method added to modify the request on the fly to
+   * allow it to process generic queries coming from kibana by
+   * validating against the security framework (contributed by Ram Kotamaraja)
+   * @param request
+   */
+  private void modifiyKibanaRequest(
+      final TomcatHttpServerRestRequest request,
+      final TomcatHttpServerRestChannel channel) {
 
-						if (!permLevel.equals(PermLevel.NONE)) {
-							authorizedTypesList.addAll(kibanaType);
-						}
-					}
+    List<String> reqTypesList = SecurityUtil.getTypes(request);
+    if (reqTypesList != null && !reqTypesList.isEmpty() && reqTypesList.size() > 0) {
+      log.debug("Not modifying the request (for kibana) as there is one or more types already associated with the request");
+      reqTypesList = null;
+      return;
+    }
 
-					
+    String kibanaPermLevel = null;
+    try {
+      kibanaPermLevel = securityService.getXContentSecurityConfiguration(getType(), getKibanaId());
+    } catch (Exception e) {
+      log.debug("No Kibana configuration found, so continuing the rest of the process: " + e.getMessage());
+      return;
+    }
 
-					log.debug("Processing kibana types  "+ kibanaTypesList);
-					log.debug("request Content =  "+ reqContent);
+    List<String> kibanaTypesList = null;
+    List<String> authorizedTypesList = new ArrayList<String>();
+    try {
+      if (kibanaPermLevel != null && kibanaPermLevel.length() > 0) {
+        kibanaTypesList = securityService.getKibanaTypes(SecurityUtil.getIndices(request));
+      }
 
-					String kibanaFilterStarter = "\"must\":[";
-					int beginIndex = reqContent.indexOf(kibanaFilterStarter);
-					
-					if (beginIndex > 0) {
-						String preReqContent = reqContent.substring(0,
-								beginIndex + kibanaFilterStarter.length());
-						String postReqContent = reqContent.substring(beginIndex
-								+ kibanaFilterStarter.length());
+      final String reqContent = request.content().toUtf8();
+      String modifiedContent = reqContent;
 
-						modifiedContent = preReqContent
-								+ "{\"or\": {\"filters\":[";
+      List<String> requestTypes = SecurityUtil.getTypes(request);
 
-						if (authorizedTypesList != null) {
-							Iterator<String> authorizedTypesItr = authorizedTypesList
-									.iterator();
-							while (authorizedTypesItr.hasNext()) {
-								modifiedContent += "{\"type\":{\"value\":\""
-										+ authorizedTypesItr.next().toString()
-										+ "\"}},";
-							}
-							modifiedContent = modifiedContent.substring(0,
-									modifiedContent.length() - 1);
-						}
+      if (requestTypes == null || requestTypes.isEmpty() || requestTypes.size() == 0) {
+        log.debug("Allowed Kibana Types are: " + kibanaTypesList);
+        if (kibanaTypesList != null || !kibanaTypesList.isEmpty()) {
 
-						modifiedContent += "]}}," + postReqContent;
-						log.debug("modified request content = " + modifiedContent);
-												
-						request.setContent(new BytesArray(modifiedContent));
-						request.setAttribute(TomcatHttpServerRestRequest.REQUEST_CONTENT_ATTRIBUTE, request.getContent());
+          Iterator<String> kibanaTypesItr = kibanaTypesList.iterator();
 
-					}
-				}
-			}
-		} catch (MalformedConfigurationException e) {
-			log.error("Cannot parse security configuration ", e);
-			SecurityUtil.send(request, channel,
-					RestStatus.INTERNAL_SERVER_ERROR,
-					"Cannot parse security configuration");
+          while (kibanaTypesItr.hasNext()) {
 
-			return;
-		} catch (Exception e) {
-			log.error("Generic error: ", e);
-			SecurityUtil.send(request, channel,
-					RestStatus.INTERNAL_SERVER_ERROR,
-					"Generic error, see log for details");
+            List<String> kibanaType = new ArrayList<String>();
+            kibanaType.add((String) kibanaTypesItr.next());
+            //At this point we have widdled down the search request, extracted the index and types.
+            //Since a kibana request is _search, it has no types, so we've extracted them and now must cross check real access against permLevel 
+            log.debug("Kibana perms checked for index: " + SecurityUtil.getIndices(request) + " and types: " + kibanaType);
+            final PermLevel permLevel = new PermLevelEvaluator(securityService.getXContentSecurityConfiguration(getType(), getId())).evaluatePerm(
+              SecurityUtil.getIndices(request),
+              kibanaType,
+              getClientHostAddress(request),
+              new TomcatUserRoleCallback(request.getHttpServletRequest(),securityService.getSettings().get("security.ssl.userattribute"))
+            );
 
-			return;
-		}
+            log.debug("Kibana artificial perm level is: " + permLevel);
 
-	}
+            if (!permLevel.equals(PermLevel.NONE)) {
+              authorizedTypesList.addAll(kibanaType);
+            }
+          }
 
-	/**
-	 * Method to return the default id (contributed by Ram Kotamaraja)
-	 * @return String - default id string
-	 */
-	 protected String getKibanaId() {
-				return "kibana";
-	 	}
+          //log.debug("Processing kibana types "+ kibanaTypesList);
+          log.debug("request Content = "+ reqContent);
 
-	@Override
-	protected String getType() {
+          String kibanaFilterStarter = "\"must\":[";
+          int beginIndex = reqContent.indexOf(kibanaFilterStarter);
+          
+          if (beginIndex > 0) {
+            String preReqContent = reqContent.substring(0, beginIndex + kibanaFilterStarter.length());
+            String postReqContent = reqContent.substring(beginIndex + kibanaFilterStarter.length());
 
-		return "actionpathfilter";
-	}
+            modifiedContent = preReqContent + "{\"or\": {\"filters\":[";
 
-	@Override
-	protected String getId() {
+            if (authorizedTypesList != null) {
+              Iterator<String> authorizedTypesItr = authorizedTypesList.iterator();
+              while (authorizedTypesItr.hasNext()) {
+                modifiedContent += "{\"type\":{\"value\":\"" + authorizedTypesItr.next().toString() + "\"}},";
+              }
+              modifiedContent = modifiedContent.substring(0, modifiedContent.length() - 1);
+            }
 
-		return "actionpathfilter";
-	}
+            modifiedContent += "]}}," + postReqContent;
+            log.debug("modified request content = " + modifiedContent);
+                        
+            request.setContent(new BytesArray(modifiedContent));
+            request.setAttribute(TomcatHttpServerRestRequest.REQUEST_CONTENT_ATTRIBUTE, request.getContent());
+
+          }
+        }
+      }
+    } catch (MalformedConfigurationException e) {
+      log.error("Cannot parse security configuration ", e);
+      SecurityUtil.send(request, channel, RestStatus.INTERNAL_SERVER_ERROR, "Cannot parse security configuration");
+
+      return;
+
+    } catch (Exception e) {
+      log.error("Generic error: ", e);
+      SecurityUtil.send(request, channel, RestStatus.INTERNAL_SERVER_ERROR, "Generic error, see log for details");
+
+      return;
+
+    }
+
+  }
+
+  /**
+  * Method to return the default id (contributed by Ram Kotamaraja)
+  * @return String - default id string
+  */
+  protected String getKibanaId() {
+    return "kibana";
+  }
+
+  @Override
+  protected String getType() {
+    return "actionpathfilter";
+  }
+
+  @Override
+  protected String getId() {
+    return "actionpathfilter";
+  }
 
 }

--- a/src/main/java/org/elasticsearch/plugins/security/http/tomcat/TomcatHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/plugins/security/http/tomcat/TomcatHttpServerTransport.java
@@ -13,6 +13,7 @@ import static org.elasticsearch.common.network.NetworkService.TcpSettings.TCP_SE
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.Arrays;
 
 import org.apache.catalina.Context;
 import org.apache.catalina.LifecycleException;
@@ -541,7 +542,14 @@ HttpServerTransport {
 					col.addPattern("/*");
 
           if (enableCors) {
-            col.removeMethod("OPTIONS");
+					  logger.debug("Cors is enabled, specifying methods excluding OPTIONS from security collection");
+            //col.removeMethod("OPTIONS");
+            col.addMethod("GET");
+            col.addMethod("PUT");
+            col.addMethod("POST");
+            col.addMethod("DELETE");
+            col.addMethod("HEAD");
+            logger.info("Protected methods are: " + Arrays.toString(col.findMethods()));
           }
 
 					constraint.addCollection(col);

--- a/src/main/java/org/elasticsearch/plugins/security/http/tomcat/TomcatHttpServerTransport.java
+++ b/src/main/java/org/elasticsearch/plugins/security/http/tomcat/TomcatHttpServerTransport.java
@@ -94,6 +94,8 @@ HttpServerTransport {
 
 	private final  Boolean useClientAuth;
 
+  final Boolean enableCors;
+
 	static {
 
 		System.setProperty("org.apache.catalina.connector.RECYCLE_FACADES",
@@ -173,6 +175,8 @@ HttpServerTransport {
 		 * 
 
 		 */
+
+    enableCors = componentSettings.getAsBoolean("cors.enabled", settings.getAsBoolean("security.cors.enabled", false));
 
 		useSSL = componentSettings.getAsBoolean("ssl.enabled",
 				settings.getAsBoolean("security.ssl.enabled", false));
@@ -433,6 +437,10 @@ HttpServerTransport {
 					final SecurityCollection col = new SecurityCollection();
 					col.addPattern("/*");
 
+          if (enableCors) {
+            col.removeMethod("OPTIONS");
+          }
+
 					constraint.addCollection(col);
 					ctx.addConstraint(constraint);
 
@@ -531,6 +539,10 @@ HttpServerTransport {
 					constraint.setDisplayName("spnego_sc_all");
 					final SecurityCollection col = new SecurityCollection();
 					col.addPattern("/*");
+
+          if (enableCors) {
+            col.removeMethod("OPTIONS");
+          }
 
 					constraint.addCollection(col);
 					ctx.addConstraint(constraint);


### PR DESCRIPTION
A few enhancements to add more flexible CORS support for browsers that need it. Always setting Access-Control-Allow-Origin to "*" is a good default, but is less flexible. Not setting Access-Control-Allow-Credentials was about the same story.

Adding 2 new settings: 
security.cors.allow-origin: $string
security.cors.allow-credentials: $bool